### PR TITLE
Fix ffmpeg executable detection on Windows

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,7 +62,8 @@ export function findFFmpegExecutable(): string | null {
     execSync('ffmpeg -version', { stdio: 'pipe' });
     return 'ffmpeg';
   } catch {
-    const localFFmpeg = path.join(process.cwd(), 'bin', 'ffmpeg');
+    const ffmpegName = platform() === 'win32' ? 'ffmpeg.exe' : 'ffmpeg';
+    const localFFmpeg = path.join(process.cwd(), 'bin', ffmpegName);
     if (existsSync(localFFmpeg)) {
       return localFFmpeg;
     }


### PR DESCRIPTION
## Summary
- Handle `.exe` when searching for local FFmpeg

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6895072cff8c832ebbea1eb0b5538ac7