### PR TITLE
Adjust padding in text-to-image layout

### DIFF
--- a/src/services/TextToImage/TextToImageService.ts
+++ b/src/services/TextToImage/TextToImageService.ts
@@ -68,8 +68,8 @@ export class TextToImageService implements ITextToImageService {
       ctx.textBaseline = this.textBaseline;
 
       // Find optimal font size that fills the height first
-      const maxWidth = canvas.width - this.padding;
-      const maxHeight = canvas.height - this.padding;
+      const maxWidth = canvas.width - this.padding * 2;
+      const maxHeight = canvas.height - this.padding * 2;
       
       let bestFontSize = 20;
       let bestLines: string[] = [];


### PR DESCRIPTION
## Summary
- Correct text-to-image maxWidth and maxHeight calculations to account for padding on both sides

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689508b7d324832eb7c8b92857c8a47f