### PR TITLE
Return sticker as image

### DIFF
--- a/src/StickerBot.ts
+++ b/src/StickerBot.ts
@@ -1,6 +1,7 @@
- import { Client, LocalAuth, Message, MessageMedia, MessageSendOptions } from 'whatsapp-web.js';
+import { Client, LocalAuth, Message, MessageMedia, MessageSendOptions } from 'whatsapp-web.js';
 import qrcode from 'qrcode-terminal';
 import clc from 'cli-color';
+import sharp from 'sharp';
 
 import { BotConfig, IBotService, StickerOptions } from './types/BotConfig';
 import { mergeWithDefaults, ResolvedBotConfig } from './config/DefaultConfig';
@@ -219,7 +220,11 @@ export class StickerBot implements IBotService {
 
   private async processStickerMessage(message: Message): Promise<ProcessedMessage> {
     const media = await message.downloadMedia();
-    return { media };
+    const webpBuffer = Buffer.from(media.data, 'base64');
+    const pngBuffer = await sharp(webpBuffer).png().toBuffer();
+    const pngBase64 = pngBuffer.toString('base64');
+    const image = new MessageMedia('image/png', pngBase64, 'sticker.png');
+    return { media: image, stickerOptions: { sendMediaAsSticker: false } };
   }
 
   private async retrieveUnreadMessages(): Promise<void> {

--- a/tests/StickerBot.test.ts
+++ b/tests/StickerBot.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import sharp from 'sharp';
+import { StickerBot } from '../src/StickerBot';
+
+// Utility to create a minimal WebP buffer
+async function createWebPBase64(): Promise<string> {
+  const pngBuffer = await sharp({
+    create: { width: 1, height: 1, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 0 } }
+  }).png().toBuffer();
+  const webpBuffer = await sharp(pngBuffer).webp().toBuffer();
+  return webpBuffer.toString('base64');
+}
+
+test('processStickerMessage converts WebP sticker to PNG image and disables sticker sending', async () => {
+  const bot = new StickerBot();
+  const base64WebP = await createWebPBase64();
+  const message = {
+    downloadMedia: async () => ({ data: base64WebP })
+  } as any;
+
+  const result = await (bot as any).processStickerMessage(message);
+
+  assert.strictEqual(result.media.mimetype, 'image/png');
+  const outputBuffer = Buffer.from(result.media.data, 'base64');
+  const pngSignature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  assert(outputBuffer.subarray(0, 8).equals(pngSignature));
+  assert.deepStrictEqual(result.stickerOptions, { sendMediaAsSticker: false });
+});


### PR DESCRIPTION
## Summary
- convert sticker responses to PNG images instead of stickers using sharp
- add test covering sticker-to-image conversion

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68950c59a190832eb513d3f03ceaabf7