### PR TITLE
feat: render emojis with fallback fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules/
 
 # Compiled TypeScript output
 dist/
+assets/fonts/NotoColorEmoji.ttf
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ COPY --from=builder --chown=stickerbot:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=stickerbot:nodejs /app/package*.json ./
 COPY --from=builder --chown=stickerbot:nodejs /app/assets ./assets
 
+# Download Noto Color Emoji font
+RUN wget -q -O /app/assets/fonts/NotoColorEmoji.ttf https://github.com/googlefonts/noto-emoji/raw/main/fonts/NotoColorEmoji.ttf && \
+    chown stickerbot:nodejs /app/assets/fonts/NotoColorEmoji.ttf
+
 ENV CHROME_BIN=/usr/bin/chromium-browser
 ENV CHROME_PATH=/usr/bin/chromium-browser
 

--- a/Makefile
+++ b/Makefile
@@ -69,17 +69,22 @@ install-linux: deps
 	@wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 	@echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
 	@sudo apt update && sudo apt install -y google-chrome-stable
+	@mkdir -p assets/fonts
+	@curl -L -o assets/fonts/NotoColorEmoji.ttf https://github.com/googlefonts/noto-emoji/raw/main/fonts/NotoColorEmoji.ttf
 
 install-macos: deps
 	@brew install ffmpeg
 	@brew install --cask google-chrome
+	@mkdir -p assets/fonts
+	@curl -L -o assets/fonts/NotoColorEmoji.ttf https://github.com/googlefonts/noto-emoji/raw/main/fonts/NotoColorEmoji.ttf
 
 install-windows: deps
 	@echo "Windows setup instructions:"
 	@echo "  1. Download FFmpeg from: https://www.gyan.dev/ffmpeg/builds/"
 	@echo "  2. Extract and add to PATH"
 	@echo "  3. Download Chrome from: https://www.google.com/chrome/"
-	@echo "  4. Run: make verify"
+	@echo "  4. Run: install.bat to fetch Noto Color Emoji font"
+	@echo "  5. Run: make verify"
 
 quick-start-linux: install-linux build verify dev
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ A WhatsApp bot that turns your text and media into stickers instantly!
 
 ## Quick Start
 
-1. **Install dependencies**
+1. **Install dependencies and fonts**
    ```bash
    npm install
+   ./install.sh    # downloads Noto Color Emoji for emoji rendering
    ```
 
 2. **Setup Chrome and FFmpeg**

--- a/install.bat
+++ b/install.bat
@@ -4,6 +4,14 @@ echo Installing StickerBot dependencies...
 echo Installing Node.js dependencies...
 npm install
 
+echo Downloading Noto Color Emoji font...
+if not exist assets\fonts mkdir assets\fonts
+if not exist assets\fonts\NotoColorEmoji.ttf (
+  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://github.com/googlefonts/noto-emoji/raw/main/fonts/NotoColorEmoji.ttf', 'assets/fonts/NotoColorEmoji.ttf')"
+) else (
+  echo Noto Color Emoji font already exists
+)
+
 echo Please install FFmpeg manually:
 echo   Download from: https://www.gyan.dev/ffmpeg/builds/
 echo   Extract and add to PATH

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,15 @@ echo "Installing StickerBot dependencies..."
 echo "Installing Node.js dependencies..."
 npm install
 
+# Download Noto Color Emoji font
+echo "Downloading Noto Color Emoji font..."
+if [ ! -f assets/fonts/NotoColorEmoji.ttf ]; then
+    mkdir -p assets/fonts
+    curl -L -o assets/fonts/NotoColorEmoji.ttf https://github.com/googlefonts/noto-emoji/raw/main/fonts/NotoColorEmoji.ttf
+else
+    echo "Noto Color Emoji font already exists"
+fi
+
 # Install ffmpeg
 echo "Installing FFmpeg..."
 if command -v ffmpeg &> /dev/null; then

--- a/src/services/TextToImage/TextToImageService.ts
+++ b/src/services/TextToImage/TextToImageService.ts
@@ -1,4 +1,6 @@
 import { createCanvas, registerFont, CanvasRenderingContext2D } from "canvas";
+import path from "path";
+import fs from "fs";
 import { direction } from "direction";
 import { ITextToImageService } from "../../types/BotConfig";
 import { DEFAULT_OPTIONS, TextToImageOptions, FontConfig } from "./defaults";
@@ -32,20 +34,34 @@ export class TextToImageService implements ITextToImageService {
 
   private initializeFont(): void {
     try {
-      registerFont(this.rtlFont.path, { 
-        family: this.rtlFont.family, 
-        weight: this.rtlFont.weight as any 
+      registerFont(this.rtlFont.path, {
+        family: this.rtlFont.family,
+        weight: this.rtlFont.weight as any
       });
-      
-      registerFont(this.ltrFont.path, { 
-        family: this.ltrFont.family, 
-        weight: this.ltrFont.weight as any 
+
+      registerFont(this.ltrFont.path, {
+        family: this.ltrFont.family,
+        weight: this.ltrFont.weight as any
       });
-      
+
       this.fontRegistered = true;
     } catch (err) {
-      console.warn("Could not register fonts, using system fonts");
+      console.warn("Could not register custom fonts, using system fonts");
       this.fontRegistered = false;
+    }
+
+    const emojiFontPath = path.resolve(__dirname, "../../../assets/fonts/NotoColorEmoji.ttf");
+    if (fs.existsSync(emojiFontPath)) {
+      try {
+        registerFont(emojiFontPath, {
+          family: "Noto Color Emoji",
+          weight: "normal" as any
+        });
+      } catch (err) {
+        console.warn("Failed to register emoji font");
+      }
+    } else {
+      console.warn("Emoji font not found; emojis may render as hex codes");
     }
   }
 
@@ -146,14 +162,16 @@ export class TextToImageService implements ITextToImageService {
   }
 
   private getFontFamily(textDirection: string): string {
+    const emojiFallback = '"Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji"';
+
     if (!this.fontRegistered) {
-      return 'Arial, sans-serif';
+      return `${emojiFallback}, Arial, sans-serif`;
     }
 
     if (textDirection === 'rtl') {
-      return `"${this.rtlFont.family}", Arial, sans-serif`;
+      return `"${this.rtlFont.family}", ${emojiFallback}, Arial, sans-serif`;
     } else {
-      return `"${this.ltrFont.family}", Arial, sans-serif`;
+      return `"${this.ltrFont.family}", ${emojiFallback}, Arial, sans-serif`;
     }
   }
 

--- a/tests/TextToImageService.test.ts
+++ b/tests/TextToImageService.test.ts
@@ -44,3 +44,33 @@ test('wrapText handles text containing newline characters', () => {
     assert(ctx.measureText(line).width <= maxWidth, 'Line exceeds maxWidth');
   }
 });
+
+test('getFontFamily includes emoji fallbacks when custom fonts are registered', () => {
+  const service = new TextToImageService();
+  const ltrFamily = (service as any).getFontFamily('ltr');
+  assert.ok(ltrFamily.startsWith('"Open Sans"'), 'LTR font should start with custom font');
+  assert.ok(ltrFamily.includes('"Noto Color Emoji"'), 'Emoji fallback missing');
+  assert.ok(ltrFamily.includes('"Apple Color Emoji"'), 'Emoji fallback missing');
+  assert.ok(ltrFamily.includes('"Segoe UI Emoji"'), 'Emoji fallback missing');
+
+  const rtlFamily = (service as any).getFontFamily('rtl');
+  assert.ok(rtlFamily.startsWith('"CustomFont"'), 'RTL font should start with custom font');
+  assert.ok(rtlFamily.includes('"Noto Color Emoji"'), 'Emoji fallback missing');
+  assert.ok(rtlFamily.includes('"Apple Color Emoji"'), 'Emoji fallback missing');
+});
+
+test('getFontFamily falls back to emoji fonts when custom fonts are unavailable', () => {
+  const service = new TextToImageService();
+  (service as any).fontRegistered = false;
+  const family = (service as any).getFontFamily('ltr');
+  assert.ok(family.startsWith('"Noto Color Emoji"'), 'Fallback should start with emoji fonts');
+  assert.ok(!family.includes('"Open Sans"'), 'Should not include custom font when fonts are unregistered');
+});
+
+test('generateImage renders emoji glyphs rather than hex codes', async () => {
+  const service = new TextToImageService();
+  const base64 = await service.generateImage('😀');
+  const buf = Buffer.from(base64, 'base64');
+  const ascii = buf.toString('utf8');
+  assert.ok(!ascii.includes('1F600'), 'Emoji was rendered as hex code');
+});


### PR DESCRIPTION
## Summary
- register "Noto Color Emoji" as a built-in fallback font so emojis render instead of hex placeholders
- expand emoji font fallback list in text rendering service
- cover emoji fallback behaviour with additional tests
- download Noto Color Emoji during setup scripts and Docker builds instead of committing the binary

## Testing
- `npm test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68950df7757c832eac155a681411099c