### PR TITLE
Track sticker production in account status

### DIFF
--- a/src/utils/StickerCounter.ts
+++ b/src/utils/StickerCounter.ts
@@ -1,0 +1,18 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const COUNT_FILE = path.join(process.cwd(), '.sticker-count');
+
+export async function loadStickerCount(): Promise<number> {
+  try {
+    const data = await fs.readFile(COUNT_FILE, 'utf-8');
+    const parsed = parseInt(data, 10);
+    return isNaN(parsed) ? 0 : parsed;
+  } catch {
+    return 0;
+  }
+}
+
+export async function saveStickerCount(count: number): Promise<void> {
+  await fs.writeFile(COUNT_FILE, String(count), 'utf-8');
+}


### PR DESCRIPTION
## Summary
- Persist sticker count and update WhatsApp status with total stickers created.

## Testing
- `npm test`
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_689519c1f5d4832ea9722c6c81d6249f