### PR TITLE
chore: add lint script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ rebuild:
 	@npm run rebuild
 
 lint:
-	@npx tsc --noEmit
+	@npm run lint
 
 format:
 	@npx prettier --write "src/**/*.ts" "*.ts" "*.js" "*.json" || echo "⚠️  Prettier not configured"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "setup:chrome": "npm run setup chrome",
     "setup:verify": "npm run setup verify",
     "setup:scripts": "npm run setup scripts",
+    "lint": "tsc --noEmit",
     "test": "node --test --require ts-node/register tests/**/*.test.ts"
   },
   "author": "",


### PR DESCRIPTION
## Summary
- add lint script using TypeScript noEmit
- run lint from makefile target

## Testing
- `npm test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68959aedfc08832e955dd8b016e98e23